### PR TITLE
Configuração inicial do .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ccls-cache/
+.replit
+replit.nix


### PR DESCRIPTION
Teste de compatibilidade entre o GitHub e o Replit por meio da adição de um arquivo .gitignore.